### PR TITLE
Add support for multiple folders

### DIFF
--- a/diaro_render/cli/main.py
+++ b/diaro_render/cli/main.py
@@ -32,8 +32,9 @@ class CLI(object):
         parser = ArgumentParser('diaro-render')
         parser.add_argument('file', metavar='FILE', nargs=1,
                             help='path to DiaroBackup.xml')
-        parser.add_argument('--folder', metavar='UID',
-                            help='folder UID to filter by')
+        parser.add_argument('--folder', metavar='UID', action='append',
+                            help='folder UID to filter by '
+                            '(may be given more than once)')
         parser.add_argument('--mediapath', help='path to media files',
                             default='')
         parser.add_argument('--thumbsuffix', help='suffix for media thumbnails',
@@ -52,7 +53,7 @@ class CLI(object):
 
             return
 
-        entries = diaro.get_entries_for_folder(self.namespace.folder)
+        entries = diaro.get_entries_for_folders(self.namespace.folder)
 
         if self.namespace.only_year:
             only_year = int(self.namespace.only_year)

--- a/diaro_render/data.py
+++ b/diaro_render/data.py
@@ -50,13 +50,14 @@ class Diaro(object):
         root = ET.parse(filename).getroot()
         self._parse_root(root)
 
-    def get_entries_for_folder(self, folder_uid):
+    def get_entries_for_folders(self, folder_uids):
         """
-        Return entries in a given folder, in date order.
+        Return entries in a given folders, in date order.
         """
 
+        folder_uids = list(folder_uids)
         entries = [entry for entry in self.entries.values()
-                   if entry.folder_uid == folder_uid]
+                   if entry.folder_uid in folder_uids]
         entries.sort(key=lambda x: x.date)
         return entries
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -203,7 +203,7 @@ class TestDiaro(object):
         assert attachment.filename == 'photo.jpg'
         assert attachment.position == '1'
 
-    def test_get_entries_for_folder(self):
+    def test_get_entries_for_folders(self):
         xml = dedent("""\
             <data version="2">
             <table name="diaro_folders">
@@ -212,6 +212,12 @@ class TestDiaro(object):
                <title>Diary entries</title>
                <color>#000000</color>
                <pattern>pattern01</pattern>
+            </r>
+            <r>
+               <uid>3</uid>
+               <title>Quotes</title>
+               <color>#111111</color>
+               <pattern>pattern02</pattern>
             </r>
             </table>
             <table name="diaro_entries">
@@ -237,6 +243,17 @@ class TestDiaro(object):
                <tags></tags>
                <primary_photo_uid>4</primary_photo_uid>
             </r>
+            <r>
+               <uid>5</uid>
+               <date>1434997052006</date>
+               <tz_offset>+01:00</tz_offset>
+               <title>Quote</title>
+               <text>quote</text>
+               <folder_uid>3</folder_uid>
+               <location_uid>4</location_uid>
+               <tags></tags>
+               <primary_photo_uid></primary_photo_uid>
+            </r>
             </table>
             </data>
             """)
@@ -246,12 +263,18 @@ class TestDiaro(object):
             fp.flush()
             diaro = Diaro(filename=fp.name)
 
-        assert len(diaro.entries) == 2
+        assert len(diaro.entries) == 3
+        assert len(diaro.folders) == 2
         assert '2' in diaro.folders
+        assert '3' in diaro.folders
 
-        entries = diaro.get_entries_for_folder('2')
+        entries = diaro.get_entries_for_folders(['2'])
         assert len(entries) == 1
         assert entries[0].title == 'title'
+
+        entries = diaro.get_entries_for_folders((x for x in ['2', '3']))
+        assert len(entries) == 2
+        assert entries[0].title == 'Quote'
 
     def get_attachments_for_entry(self, entry_uid):
         xml = dedent("""\


### PR DESCRIPTION
This change adds support for reading entries from multiple folders and interleaving them chronologically.

Signed-off-by: Tim Waugh <twaugh@redhat.com>